### PR TITLE
Fixed text light clr in trending mantra homepage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -557,11 +557,13 @@ body.admin-theme {
 /* Modern Text Styles */
 .text-gradient {
   background: linear-gradient(135deg,
-      hsl(var(--primary)) 0%,
-      hsl(var(--accent)) 100%);
+      #6d28d9 0%,
+      #7c3aed 50%,
+      #8b5cf6 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  color: #374151; /* Fallback color for browsers that don't support background-clip */
 }
 
 .hero-text-gradient {

--- a/components/mantra-card.tsx
+++ b/components/mantra-card.tsx
@@ -47,7 +47,7 @@ export function MantraCard({ mantra }: MantraCardProps) {
         <Card className="h-full card-hover glass-effect rounded-2xl overflow-hidden group">
           <CardHeader className="pb-4">
             <div className="flex justify-between items-start mb-2">
-              <CardTitle className="text-xl font-playfair text-gradient line-clamp-2 leading-tight group-hover:text-purple-700 transition-colors">
+              <CardTitle className="text-xl font-playfair text-gray-900 line-clamp-2 leading-tight group-hover:text-purple-700 transition-colors font-semibold">
                 {mantra.title}
               </CardTitle>
               <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
🎯 What Was Fixed:
Issue 1: Text Gradient Not Working
Problem: CSS variables --primary and --accent were not properly defined, causing transparent text Solution: Updated .text-gradient class with explicit purple gradient colors Issue 2: Fallback Color
Problem: No fallback color when gradient doesn't work Solution: Added color: #374151 as fallback for browsers that don't support background-clip: text Issue 3: MantraCard Title
Problem: Using problematic text-gradient class
Solution: Changed to text-gray-900 for reliable dark text with purple hover 🎨 New Styling:
MantraCard Title:
Default: Dark gray (text-gray-900) - clearly visible Hover: Purple (group-hover:text-purple-700) - nice accent color Font: Playfair Display with semibold weight
Text Gradient (Fixed):
Colors: Purple gradient from #6d28d9 → #7c3aed → #8b5cf6 Fallback: Dark gray (#374151) for compatibility